### PR TITLE
tests: loosen regex to accommodate variants

### DIFF
--- a/test/sled_test.exs
+++ b/test/sled_test.exs
@@ -32,7 +32,7 @@ defmodule SledTest do
 
   test "open invalid db_path" do
     assert_raise ErlangError,
-                 ~r/Erlang error: \"sled::Error::Io\(Custom { kind: InvalidInput, error: .*/,
+                 ~r/Erlang error: \"sled::Error::Io.+{ kind: InvalidInput,.*/,
                  fn -> Sled.open("\0") end
   end
 


### PR DESCRIPTION
presumably this is due to differing rust or elixir versions.

erlang 24.1.7
elixir 1.13.1

Running this on `FreeBSD 13.0-RELEASE amd64`, with `rustc 1.57.0`, 22 tests & 1 failure:

## pre patch

```elixir
  * ...
  * test open db_path (1.4ms) [L#23]
  * test open invalid db_path (3.5ms) [L#33]

  1) test open invalid db_path (SledTest)
     test/sled_test.exs:33
     Wrong message for ErlangError
     expected:
       ~r/Erlang error: \"sled::Error::Io\(Custom { kind: InvalidInput, error: .*/
     actual:
       "Erlang error: \"sled::Error::Io(Error { kind: InvalidInput, message: \\\"data provided contains a nul byte\\\" })\""
     code: assert_raise ErlangError,
     stacktrace:
       test/sled_test.exs:34: (test)
```

## post patch

```elixir
  * test open invalid db_path (3.2ms) [L#33]
  * ...
Finished in 0.8 seconds (0.00s async, 0.8s sync)
5 doctests, 22 tests, 0 failures
```

I'm new to rustler, so it's not clear to me yet where this error originates, but the supplied patch *should* accommodate both previous and current errors.

